### PR TITLE
Fix content.opf

### DIFF
--- a/minimal/OEBPS/content.opf
+++ b/minimal/OEBPS/content.opf
@@ -3,7 +3,7 @@
 
 	<metadata>
 	    <dc:title id="t1">Sample .epub Book</dc:title>
-	    <dc:creator opf:role="aut">Thomas Hansen</dc:creator>
+	    <dc:creator role="aut">Thomas Hansen</dc:creator>
 	    <dc:identifier id="db-id">isbn</dc:identifier>
 	    <meta property="dcterms:modified">2014-03-27T09:14:09Z</meta>
 	    <dc:language>en</dc:language>


### PR DESCRIPTION
I was unable to open the minimal epub file in Apple Books (2.4) until I made this fix.

```
$ xmllint OEBPS/content.opf                                                                                            
OEBPS/content.opf:6: namespace error : Namespace prefix opf for role on creator is not defined                         
            <dc:creator opf:role="aut">
```

Namespace prefix `opf` is not defined. The namespace, `http://www.idpf.org/2007/opf`, is already set as the default namespace, so the prefix can simply be removed.